### PR TITLE
Add click-tracking config files to sublime-prod-backend

### DIFF
--- a/click-tracking-ap-southeast-2.json
+++ b/click-tracking-ap-southeast-2.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.ap-southeast-2.amazonaws.com/click-tracking:1.80.23"
+    }
+  ]

--- a/click-tracking-ap-southeast-2.json
+++ b/click-tracking-ap-southeast-2.json
@@ -1,6 +1,6 @@
 [
     {
       "name": "click-tracking",
-      "imageUri": "948971135452.dkr.ecr.ap-southeast-2.amazonaws.com/click-tracking:1.80.23"
+      "imageUri": "948971135452.dkr.ecr.ap-southeast-2.amazonaws.com/click-tracking:1.81.4-rc.0"
     }
   ]

--- a/click-tracking-ca-central-1.json
+++ b/click-tracking-ca-central-1.json
@@ -1,6 +1,6 @@
 [
     {
       "name": "click-tracking",
-      "imageUri": "948971135452.dkr.ecr.ca-central-1.amazonaws.com/click-tracking:1.80.23"
+      "imageUri": "948971135452.dkr.ecr.ca-central-1.amazonaws.com/click-tracking:1.81.4-rc.0"
     }
   ]

--- a/click-tracking-ca-central-1.json
+++ b/click-tracking-ca-central-1.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.ca-central-1.amazonaws.com/click-tracking:1.80.23"
+    }
+  ]

--- a/click-tracking-eu-central-2.json
+++ b/click-tracking-eu-central-2.json
@@ -1,6 +1,6 @@
 [
     {
       "name": "click-tracking",
-      "imageUri": "948971135452.dkr.ecr.eu-central-2.amazonaws.com/click-tracking:1.80.23"
+      "imageUri": "948971135452.dkr.ecr.eu-central-2.amazonaws.com/click-tracking:1.81.4-rc.0"
     }
   ]

--- a/click-tracking-eu-central-2.json
+++ b/click-tracking-eu-central-2.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.eu-central-2.amazonaws.com/click-tracking:1.80.23"
+    }
+  ]

--- a/click-tracking-eu-north-1.json
+++ b/click-tracking-eu-north-1.json
@@ -1,6 +1,6 @@
 [
     {
       "name": "click-tracking",
-      "imageUri": "948971135452.dkr.ecr.eu-north-1.amazonaws.com/click-tracking:1.80.23"
+      "imageUri": "948971135452.dkr.ecr.eu-north-1.amazonaws.com/click-tracking:1.81.4-rc.0"
     }
   ]

--- a/click-tracking-eu-north-1.json
+++ b/click-tracking-eu-north-1.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.eu-north-1.amazonaws.com/click-tracking:1.80.23"
+    }
+  ]

--- a/click-tracking-eu-west-1.json
+++ b/click-tracking-eu-west-1.json
@@ -1,6 +1,6 @@
 [
     {
       "name": "click-tracking",
-      "imageUri": "948971135452.dkr.ecr.eu-west-1.amazonaws.com/click-tracking:1.80.23"
+      "imageUri": "948971135452.dkr.ecr.eu-west-1.amazonaws.com/click-tracking:1.81.4-rc.0"
     }
   ]

--- a/click-tracking-eu-west-1.json
+++ b/click-tracking-eu-west-1.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.eu-west-1.amazonaws.com/click-tracking:1.80.23"
+    }
+  ]

--- a/click-tracking-eu-west-2.json
+++ b/click-tracking-eu-west-2.json
@@ -1,6 +1,6 @@
 [
     {
       "name": "click-tracking",
-      "imageUri": "948971135452.dkr.ecr.eu-west-2.amazonaws.com/click-tracking:1.80.23"
+      "imageUri": "948971135452.dkr.ecr.eu-west-2.amazonaws.com/click-tracking:1.81.4-rc.0"
     }
   ]

--- a/click-tracking-eu-west-2.json
+++ b/click-tracking-eu-west-2.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.eu-west-2.amazonaws.com/click-tracking:1.80.23"
+    }
+  ]

--- a/click-tracking-us-east-1.json
+++ b/click-tracking-us-east-1.json
@@ -1,6 +1,6 @@
 [
     {
       "name": "click-tracking",
-      "imageUri": "948971135452.dkr.ecr.us-east-1.amazonaws.com/click-tracking:1.80.23"
+      "imageUri": "948971135452.dkr.ecr.us-east-1.amazonaws.com/click-tracking:1.81.4-rc.0"
     }
   ]

--- a/click-tracking-us-east-1.json
+++ b/click-tracking-us-east-1.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.us-east-1.amazonaws.com/click-tracking:1.80.23"
+    }
+  ]

--- a/click-tracking-us-east-2.json
+++ b/click-tracking-us-east-2.json
@@ -1,6 +1,6 @@
 [
     {
       "name": "click-tracking",
-      "imageUri": "948971135452.dkr.ecr.us-east-2.amazonaws.com/click-tracking:1.80.23"
+      "imageUri": "948971135452.dkr.ecr.us-east-2.amazonaws.com/click-tracking:1.81.4-rc.0"
     }
   ]

--- a/click-tracking-us-east-2.json
+++ b/click-tracking-us-east-2.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.us-east-2.amazonaws.com/click-tracking:1.80.23"
+    }
+  ]

--- a/click-tracking-us-gov-west-1.json
+++ b/click-tracking-us-gov-west-1.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "106524781139.dkr.ecr.us-gov-west-1.amazonaws.com/click-tracking:1.80.23"
+    }
+  ]

--- a/click-tracking-us-gov-west-1.json
+++ b/click-tracking-us-gov-west-1.json
@@ -1,6 +1,6 @@
 [
     {
       "name": "click-tracking",
-      "imageUri": "106524781139.dkr.ecr.us-gov-west-1.amazonaws.com/click-tracking:1.80.23"
+      "imageUri": "106524781139.dkr.ecr.us-gov-west-1.amazonaws.com/click-tracking:1.81.4-rc.0"
     }
   ]

--- a/click-tracking-us-west-1.json
+++ b/click-tracking-us-west-1.json
@@ -1,6 +1,6 @@
 [
     {
       "name": "click-tracking",
-      "imageUri": "948971135452.dkr.ecr.us-west-1.amazonaws.com/click-tracking:1.80.23"
+      "imageUri": "948971135452.dkr.ecr.us-west-1.amazonaws.com/click-tracking:1.81.4-rc.0"
     }
   ]

--- a/click-tracking-us-west-1.json
+++ b/click-tracking-us-west-1.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.us-west-1.amazonaws.com/click-tracking:1.80.23"
+    }
+  ]

--- a/click-tracking-us-west-2.json
+++ b/click-tracking-us-west-2.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.us-west-2.amazonaws.com/click-tracking:1.80.23"
+    }
+  ]

--- a/click-tracking-us-west-2.json
+++ b/click-tracking-us-west-2.json
@@ -1,6 +1,6 @@
 [
     {
       "name": "click-tracking",
-      "imageUri": "948971135452.dkr.ecr.us-west-2.amazonaws.com/click-tracking:1.80.23"
+      "imageUri": "948971135452.dkr.ecr.us-west-2.amazonaws.com/click-tracking:1.81.4-rc.0"
     }
   ]

--- a/click-tracking.json
+++ b/click-tracking.json
@@ -1,6 +1,6 @@
 [
     {
       "name": "click-tracking",
-      "imageUri": "sublimesec/click-tracking:1.80.23"
+      "imageUri": "sublimesec/click-tracking:1.81.4-rc.0"
     }
   ]

--- a/click-tracking.json
+++ b/click-tracking.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "sublimesec/click-tracking:1.80.23"
+    }
+  ]


### PR DESCRIPTION
## Summary
- Adds `click-tracking-{region}.json` files for all 11 regions + legacy no-region DockerHub file
- Uses version `1.80.23` matching current backend services
- Required for CodePipeline to deploy click-tracking alongside bora/mantis/nugget

## Context
Click-tracking ECS service exists but was missing from the backend deployment pipeline. This adds the config files that CodePipeline reads during deploy.

Made with [Cursor](https://cursor.com)