### PR TITLE
Add click-tracking ECS config files

### DIFF
--- a/click-tracking-ap-southeast-2.json
+++ b/click-tracking-ap-southeast-2.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.ap-southeast-2.amazonaws.com/click-tracking-staging:1.75.54-rc.1"
+    }
+  ]

--- a/click-tracking-ca-central-1.json
+++ b/click-tracking-ca-central-1.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.ca-central-1.amazonaws.com/click-tracking-staging:1.75.54-rc.1"
+    }
+  ]

--- a/click-tracking-eu-central-2.json
+++ b/click-tracking-eu-central-2.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.eu-central-2.amazonaws.com/click-tracking-staging:1.75.54-rc.1"
+    }
+  ]

--- a/click-tracking-eu-north-1.json
+++ b/click-tracking-eu-north-1.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.eu-north-1.amazonaws.com/click-tracking-staging:1.75.54-rc.1"
+    }
+  ]

--- a/click-tracking-eu-west-1.json
+++ b/click-tracking-eu-west-1.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.eu-west-1.amazonaws.com/click-tracking-staging:1.75.54-rc.1"
+    }
+  ]

--- a/click-tracking-eu-west-2.json
+++ b/click-tracking-eu-west-2.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.eu-west-2.amazonaws.com/click-tracking-staging:1.75.54-rc.1"
+    }
+  ]

--- a/click-tracking-us-east-1.json
+++ b/click-tracking-us-east-1.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.us-east-1.amazonaws.com/click-tracking-staging:1.75.54-rc.1"
+    }
+  ]

--- a/click-tracking-us-east-2.json
+++ b/click-tracking-us-east-2.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.us-east-2.amazonaws.com/click-tracking-staging:1.75.54-rc.1"
+    }
+  ]

--- a/click-tracking-us-gov-west-1.json
+++ b/click-tracking-us-gov-west-1.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "106524781139.dkr.ecr.us-gov-west-1.amazonaws.com/click-tracking-staging:1.75.54-rc.1"
+    }
+  ]

--- a/click-tracking-us-west-1.json
+++ b/click-tracking-us-west-1.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.us-west-1.amazonaws.com/click-tracking-staging:1.75.54-rc.1"
+    }
+  ]

--- a/click-tracking-us-west-2.json
+++ b/click-tracking-us-west-2.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "948971135452.dkr.ecr.us-west-2.amazonaws.com/click-tracking-staging:1.75.54-rc.1"
+    }
+  ]

--- a/click-tracking.json
+++ b/click-tracking.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "click-tracking",
+      "imageUri": "sublimesec/click-tracking:1.75.54-rc.1"
+    }
+  ]


### PR DESCRIPTION
## Summary
- Adds `click-tracking*.json` ECS config files for all regions
- The click-tracking service was added to go-mantis Docker builds but the ECS config files were never created in this repo
- This causes the CD to Staging workflow to fail (`sed: can't read click-tracking*.json: No such file or directory`)

## Test plan
- [ ] Merge and verify the next CD to Staging run passes the "Deploy to Staging ECS" job

🤖 Generated with [Claude Code](https://claude.com/claude-code)